### PR TITLE
allow different color death icons for bots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bots/*
 !bots/nodebot
 !bots/rubybot
 !bots/bots.json
+
+.DS_Store

--- a/game.js
+++ b/game.js
@@ -3,7 +3,8 @@ var gridIds = {
   p2Spawn:'1',
   player1:'r',
   player2:'b',
-  dead:'x',
+  dead1:'x',
+  dead2:'X',
   energy:'*',
   empty:'.'
 };
@@ -54,7 +55,7 @@ exports.doTurn = function(state, p1Moves, p2Moves, testing) {
   }
 
   // move
-  var re = new RegExp(gridIds.dead, 'g');
+  var re = new RegExp(gridIds.dead1, 'gi');
   state.grid = state.grid.replace(re, gridIds.empty);
   re = new RegExp(gridIds.player1+'|'+gridIds.player2, 'g');
   var newState = copyObj(state);
@@ -63,7 +64,7 @@ exports.doTurn = function(state, p1Moves, p2Moves, testing) {
     if(adjacent(state, move.to, move.from) && state.grid[move.from]===gridIds.player1) {
       setIndex(state, move.from, gridIds.empty);
       if(newState.grid[move.to]===gridIds.player1 || newState.grid[move.to]===gridIds.player2) {
-        setIndex(newState, move.to, gridIds.dead);
+        setIndex(newState, move.to, gridIds.dead1);
       }
       else {
         setIndex(newState, move.to, gridIds.player1);
@@ -74,7 +75,7 @@ exports.doTurn = function(state, p1Moves, p2Moves, testing) {
     if(adjacent(state, move.to, move.from) && state.grid[move.from]===gridIds.player2) {
       setIndex(state, move.from, gridIds.empty);
       if(newState.grid[move.to]===gridIds.player1 || newState.grid[move.to]===gridIds.player2) {
-        setIndex(newState, move.to, gridIds.dead);
+        setIndex(newState, move.to, gridIds.dead2);
       }
       else {
         setIndex(newState, move.to, gridIds.player2);
@@ -85,7 +86,7 @@ exports.doTurn = function(state, p1Moves, p2Moves, testing) {
   var unmovedP2s = getAllIndices(state.grid, gridIds.player2);
   unmovedP1s.forEach(function(index) {
     if(newState.grid[index]===gridIds.player1 || newState.grid[index]===gridIds.player2) {
-      setIndex(newState, index, gridIds.dead);
+      setIndex(newState, index, gridIds.dead1);
     }
     else {
       setIndex(newState, index, gridIds.player1);
@@ -93,7 +94,7 @@ exports.doTurn = function(state, p1Moves, p2Moves, testing) {
   });
   unmovedP2s.forEach(function(index) {
     if(newState.grid[index]===gridIds.player1 || newState.grid[index]===gridIds.player2) {
-      setIndex(newState, index, gridIds.dead);
+      setIndex(newState, index, gridIds.dead2);
     }
     else {
       setIndex(newState, index, gridIds.player2);
@@ -120,33 +121,38 @@ exports.doTurn = function(state, p1Moves, p2Moves, testing) {
     });
   });
 
-  var dead = [];
+  var dead1 = [];
+  var dead2 = [];
   p1Indices.forEach(function(p1Index) {
     var surroundingP1 = battleData.p1[p1Index];
     getAdjacentIndices(state, p1Index).forEach(function(adjIndex) {
       if(battleData.p2[adjIndex]) {
         var surroundingP2 = battleData.p2[adjIndex];
         if(surroundingP1 > surroundingP2) {
-          if(dead.indexOf(p1Index) === -1)
-            dead.push(p1Index);
+          if(dead1.indexOf(p1Index) === -1)
+            dead1.push(p1Index);
         }
         else if(surroundingP1 === surroundingP2) {
-          if(dead.indexOf(p1Index) === -1)
-            dead.push(p1Index);
-          if(dead.indexOf(adjIndex) === -1)
-            dead.push(adjIndex);
+          if(dead1.indexOf(p1Index) === -1)
+            dead1.push(p1Index);
+          if(dead2.indexOf(adjIndex) === -1)
+            dead2.push(adjIndex);
         }
         else {
-          if(dead.indexOf(adjIndex) === -1)
-            dead.push(adjIndex);
+          if(dead2.indexOf(adjIndex) === -1)
+            dead2.push(adjIndex);
         }
       }
     });
   });
 
-  dead.forEach(function(index) {
-    setIndex(state, index, gridIds.dead);
-  })
+  dead1.forEach(function(index) {
+    setIndex(state, index, gridIds.dead1);
+  });
+
+  dead2.forEach(function(index) {
+    setIndex(state, index, gridIds.dead2);
+  });
 
   // raze
   if(state.grid[state.p1.spawn] === gridIds.player2) {

--- a/public/scripts/test.js
+++ b/public/scripts/test.js
@@ -194,7 +194,22 @@ function showTurn(state) {
           ctx.drawImage(energyImage, 679, 51, 94, 94, x-coordWidth/2, y-coordHeight/2, coordWidth, coordHeight);
           break;
         case 'x':
-          ctx.fillStyle = 'grey';
+          ctx.fillStyle = '#F26140';
+          ctx.beginPath();
+          ctx.arc(x, y, coordWidth/2-2, 0, 2*Math.PI);
+          ctx.fill();
+          ctx.strokeStyle = 'black';
+          ctx.beginPath();
+          ctx.moveTo(x-coordWidth/4, y-coordWidth/4);
+          ctx.lineTo(x+coordWidth/4, y+coordWidth/4);
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(x-coordWidth/4, y+coordWidth/4);
+          ctx.lineTo(x+coordWidth/4, y-coordWidth/4);
+          ctx.stroke();
+          break;
+        case 'X':
+          ctx.fillStyle = '#6EA1D7';
           ctx.beginPath();
           ctx.arc(x, y, coordWidth/2-2, 0, 2*Math.PI);
           ctx.fill();


### PR DESCRIPTION
Made it easier when testing battle patterns to see which bots died.

![screen shot 2014-01-29 at 4 46 06 pm](https://f.cloud.github.com/assets/405400/2036356/f8352a40-8949-11e3-991a-e386f4bdb4e7.png)
